### PR TITLE
Replace discontinued golint linter with revive

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,4 +1,4 @@
-name: Lint 
+name: Lint
 
 on:
   pull_request:
@@ -14,5 +14,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.29
+          version: v1.43.0
           args: --timeout=2m30s

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -7,7 +7,7 @@ linters:
     - gocritic
     - gocyclo
     - goimports
-    - golint
+    - revive
     - gosec
     - gosimple
     - govet


### PR DESCRIPTION
> WARN [runner] The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner.  Replaced by revive.

https://github.com/golangci/golangci-lint/issues/1892

Signed-off-by: Timofey Ilinykh <timofey.ilinykh@absa.africa>