### PR TITLE
Replace deprecated Normalize() call

### DIFF
--- a/setup.go
+++ b/setup.go
@@ -68,21 +68,12 @@ func parseTTL(opt, arg string) (uint32, error) {
 	}
 	return uint32(t), nil
 }
+
 func parse(c *caddy.Controller) (*Gateway, error) {
 	gw := newGateway()
 
 	for c.Next() {
-		zones := c.RemainingArgs()
-		gw.Zones = zones
-
-		if len(gw.Zones) == 0 {
-			gw.Zones = make([]string, len(c.ServerBlockKeys))
-			copy(gw.Zones, c.ServerBlockKeys)
-		}
-
-		for i, str := range gw.Zones {
-			gw.Zones[i] = plugin.Host(str).Normalize()
-		}
+		gw.Zones = plugin.OriginsFromArgsOrServerBlock(c.RemainingArgs(), c.ServerBlockKeys)
 
 		for c.NextBlock() {
 			key := c.Val()


### PR DESCRIPTION
Replace deprecated `plugin.Normalize()` call with `plugin.OriginsFromArgsOrServerBlock()`, following the deprecation warning in the logs:
```
k8gb-coredns-f658bf78-lcv4d coredns [WARNING] An external plugin (/home/runner/work/coredns-crd-plugin/coredns-crd-plugin/setup.go line 84) is using the deprecated function Normalize. 
This will be removed in a future versions of CoreDNS. 
The plugin should be updated to use OriginsFromArgsOrServerBlock or NormalizeExact instead.
```
See https://github.com/coredns/coredns/pull/4648 for more information.
Signed-off-by: Timofey Ilinykh <timofey.ilinykh@absa.africa>