### PR TITLE
Fix release changelog

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+      fetch-depth: 0
     - name: Set up Go
       uses: actions/setup-go@v2
       with:


### PR DESCRIPTION
goreleaser requires full history for changelog generation.

Signed-off-by: Dinar Valeev <dinar.valeev@absa.africa>