### PR TITLE
Fix failing main

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ on:
       - '.spelling'
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - '**.md'
       - '**.svg'
@@ -39,5 +39,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           version: v1.45.0
-          args: --timeout=3m
-
+          args: --timeout=3m30s

--- a/.github/workflows/terratest.yaml
+++ b/.github/workflows/terratest.yaml
@@ -9,7 +9,7 @@ on:
       - '.spelling'
   pull_request:
     branches:
-      - master
+      - main
     paths-ignore:
       - '**.md'
       - '**.svg'

--- a/go.mod
+++ b/go.mod
@@ -128,3 +128,5 @@ require (
 )
 
 replace github.com/gogo/protobuf => github.com/gogo/protobuf v1.3.2
+
+exclude go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738

--- a/go.sum
+++ b/go.sum
@@ -1483,7 +1483,6 @@ go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.3/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.5/go.mod h1:G5EMThwa9y8QZGBClrRx5EY+Yw9kAhnjy3bSjsnlVTQ=
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=
-go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mIZCrds/GIG4ncV9HhK5PX7jPg=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489 h1:1JFLBqwIgdyHN1ZtgjTBwO+blA6gVOmZurpiMEsETKo=
 go.etcd.io/etcd v0.5.0-alpha.5.0.20200910180754-dd1b699fc489/go.mod h1:yVHk9ub3CSBatqGNg7GRmsnfLWtoW60w4eDYfh7vHDg=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=


### PR DESCRIPTION
related to #28
- dependabot kept reporting error on wrong references in go.sum
- for pull-requests the master branch was used instead of main
- linetr in main crashed within 3m 1s on timeout. I increased it to 3m30s

Signed-off-by: kuritka <kuritka@gmail.com>