### PR TITLE
Switching terratests from UDP to TCP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ import-image:
 
 deploy-app: image import-image
 	kubectl config use-context k3d-coredns-crd
-	kubectl apply -f terratest/example/ns.yaml 
+	kubectl apply -f terratest/example/ns.yaml
 	kubectl create -n coredns configmap geodata --from-file terratest/geogen/geoip.mmdb || true
 	kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/external-dns/master/docs/contributing/crd-source/crd-manifest.yaml
 	helm repo add coredns https://coredns.github.io/helm
@@ -73,6 +73,7 @@ deploy-app: image import-image
 	helm upgrade -i coredns -n coredns charts/coredns \
 		-f terratest/helm_values.yaml \
 		--set coredns.image.tag=${TAG}
+	kubectl apply -f terratest/coredns-tcp-svc.yaml
 
 # updates source code with license headers
 license: golic

--- a/k3d-cluster.yaml
+++ b/k3d-cluster.yaml
@@ -4,6 +4,9 @@ metadata:
   name: coredns-crd
 network: k3d-action-bridge-network
 ports:
+- port: 1053:30053/tcp
+  nodeFilters:
+  - loadbalancer
 - port: 1053:53/udp
   nodeFilters:
   - loadbalancer

--- a/terratest/coredns-tcp-svc.yaml
+++ b/terratest/coredns-tcp-svc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: coredns-tcp
+  namespace: coredns
+spec:
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: coredns
+  ports:
+  - name: tcp-53
+    port: 53
+    protocol: TCP
+    targetPort: 53
+    nodePort: 30053

--- a/terratest/test/helper.go
+++ b/terratest/test/helper.go
@@ -30,6 +30,7 @@ import (
 
 const (
 	DefaultTimeout time.Duration = 5 * time.Second
+	protocol                     = "tcp"
 )
 
 type clientIP struct {
@@ -78,7 +79,7 @@ func queryDNS(dnsServer string, dnsPort int, dnsName string, dnsType uint16, cli
 	if !clientIP.IsEmpty() {
 		m.Extra = append(m.Extra, clientIP.Opts)
 	}
-	c.Net = "udp4"
+	c.Net = protocol
 	c.Dialer = &net.Dialer{}
 
 	m.SetQuestion(dnsName, dnsType)


### PR DESCRIPTION
For the reason of running terratests on different container engines (e.g.: colima) I change the DIG in terratests from UDP to TCP. This change requires additional work on exposing TCP service, cluster port etc.

Signed-off-by: kuritka <kuritka@gmail.com>