### PR TITLE
Ignore caddy v2 dependency

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+      - dependency-name: "github.com/coredns/caddy"
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
v2 created 4years ago and doesn't seem to be maintained