### PR TITLE
update DNSEndpoint CRD url

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ deploy-app: image import-image
 	kubectl config use-context k3d-coredns-crd
 	kubectl apply -f terratest/example/ns.yaml
 	kubectl create -n coredns configmap geodata --from-file terratest/geogen/geoip.mmdb || true
-	kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/heads/master/charts/external-dns/crds/dnsendpoint.yaml
+	kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/heads/master/charts/external-dns/crds/dnsendpoints.externaldns.k8s.io.yaml
 	helm repo add coredns https://coredns.github.io/helm
 	helm repo update
 	cd charts/coredns && helm dependency update


### PR DESCRIPTION
External DNS changed the URL where they keep the DNSEndpoint CRD, which broke our pipeline:
```
kubectl apply -f https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/heads/master/charts/external-dns/crds/dnsendpoint.yaml
error: unable to read URL "https://raw.githubusercontent.com/kubernetes-sigs/external-dns/refs/heads/master/charts/external-dns/crds/dnsendpoint.yaml", server reported 404 Not Found, status code=404
```