### PR TITLE
support multiple filters

### DIFF
--- a/charts/coredns/values.yaml
+++ b/charts/coredns/values.yaml
@@ -30,4 +30,5 @@ coredns:
       configBlock: |-
         apex dns1
         filter k8gb.absa.oss/dnstype=local
+        filter k8gb.absa.oss/dnstype=extdns
         loadbalance weight

--- a/common/k8sctrl/ctrl.go
+++ b/common/k8sctrl/ctrl.go
@@ -37,7 +37,6 @@ import (
 type KubeController struct {
 	client      dnsendpoint.ExtDNSInterface
 	controllers []cache.SharedIndexInformer
-	labelFilter string
 	hasSynced   bool
 	epc         cache.SharedIndexInformer
 }
@@ -64,23 +63,24 @@ var Resources = struct {
 	},
 }
 
-func NewKubeController(ctx context.Context, c *dnsendpoint.ExtDNSClient, label string) *KubeController {
+func NewKubeController(ctx context.Context, c *dnsendpoint.ExtDNSClient, labels []string) *KubeController {
 	ctrl := &KubeController{
-		client:      c,
-		labelFilter: label,
+		client: c,
 	}
-	endpointController := cache.NewSharedIndexInformer(
-		&cache.ListWatch{
-			ListFunc:  endpointLister(ctx, ctrl.client, core.NamespaceAll, ctrl.labelFilter),
-			WatchFunc: endpointWatcher(ctx, ctrl.client, core.NamespaceAll, ctrl.labelFilter),
-		},
-		&v1alpha1.DNSEndpoint{},
-		defaultResyncPeriod,
-		cache.Indexers{endpointHostnameIndex: endpointHostnameIndexFunc},
-	)
-	ctrl.epc = endpointController
-	Resources.DNSEndpoint.Lookup = ctrl.getEndpointByName
-	ctrl.controllers = append(ctrl.controllers, endpointController)
+	for _, label := range labels {
+		endpointController := cache.NewSharedIndexInformer(
+			&cache.ListWatch{
+				ListFunc:  endpointLister(ctx, ctrl.client, core.NamespaceAll, label),
+				WatchFunc: endpointWatcher(ctx, ctrl.client, core.NamespaceAll, label),
+			},
+			&v1alpha1.DNSEndpoint{},
+			defaultResyncPeriod,
+			cache.Indexers{endpointHostnameIndex: endpointHostnameIndexFunc},
+		)
+		ctrl.epc = endpointController
+		Resources.DNSEndpoint.Lookup = ctrl.getEndpointByName
+		ctrl.controllers = append(ctrl.controllers, endpointController)
+	}
 	return ctrl
 }
 
@@ -109,7 +109,7 @@ func (ctrl *KubeController) HasSynced() bool {
 	return ctrl.hasSynced
 }
 
-func endpointLister(ctx context.Context, c dnsendpoint.ExtDNSInterface, ns, label string) func(meta.ListOptions) (runtime.Object, error) {
+func endpointLister(ctx context.Context, c dnsendpoint.ExtDNSInterface, ns string, label string) func(meta.ListOptions) (runtime.Object, error) {
 	return func(opts meta.ListOptions) (runtime.Object, error) {
 		opts.LabelSelector = label
 		return c.DNSEndpoints(ns).List(ctx, opts)

--- a/common/k8sctrl/ctrl_test.go
+++ b/common/k8sctrl/ctrl_test.go
@@ -34,6 +34,7 @@ import (
 	dnsendpoint "github.com/k8gb-io/coredns-crd-plugin/extdns"
 	"github.com/stretchr/testify/assert"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/cache"
 )
 
 func TestKubeController(t *testing.T) {
@@ -137,7 +138,7 @@ func TestKubeController(t *testing.T) {
 		assert.Equal(t, 1, len(k8sctrl.controllers))
 	})
 
-	k8sctrl.epc = mcache
+	k8sctrl.endpointControllers = []cache.SharedIndexInformer{mcache}
 
 	t.Run("get no-geo endpoint by name", func(t *testing.T) {
 		lep := k8sctrl.getEndpointByName(host, clientIP, "")

--- a/common/k8sctrl/ctrl_test.go
+++ b/common/k8sctrl/ctrl_test.go
@@ -131,7 +131,7 @@ func TestKubeController(t *testing.T) {
 
 	var k8sctrl *KubeController
 	t.Run("initialize", func(t *testing.T) {
-		k8sctrl = NewKubeController(context.TODO(), client, label)
+		k8sctrl = NewKubeController(context.TODO(), client, []string{label})
 		assert.NotNil(t, k8sctrl)
 		assert.False(t, k8sctrl.HasSynced())
 		assert.Equal(t, 1, len(k8sctrl.controllers))

--- a/k8s.go
+++ b/k8s.go
@@ -30,7 +30,7 @@ import (
 )
 
 // RunKubeController kicks off the k8s controllers
-func RunKubeController(ctx context.Context, cfg *restclient.Config, filter string) (*k8sctrl.KubeController, error) {
+func RunKubeController(ctx context.Context, cfg *restclient.Config, filters []string) (*k8sctrl.KubeController, error) {
 
 	err := dnsendpoint.AddToScheme(scheme.Scheme)
 	if err != nil {
@@ -42,7 +42,7 @@ func RunKubeController(ctx context.Context, cfg *restclient.Config, filter strin
 		return nil, err
 	}
 
-	ctrl := k8sctrl.NewKubeController(ctx, kubeClient, filter)
+	ctrl := k8sctrl.NewKubeController(ctx, kubeClient, filters)
 
 	go ctrl.Run()
 

--- a/k8scrd.go
+++ b/k8scrd.go
@@ -36,13 +36,13 @@ type K8sCRD struct {
 	container  service.PluginContainer
 }
 
-func NewK8sCRD(ct configType, filter string) (*K8sCRD, error) {
+func NewK8sCRD(ct configType, filters []string) (*K8sCRD, error) {
 	cfg, rct, err := configFactory(ct)
 	if err != nil {
 		return nil, err
 	}
 	log.Infof("Running '%s' kube controller", rct)
-	ctrl, err := RunKubeController(context.Background(), cfg, filter)
+	ctrl, err := RunKubeController(context.Background(), cfg, filters)
 	if err != nil {
 		return nil, err
 	}

--- a/setup.go
+++ b/setup.go
@@ -34,7 +34,7 @@ import (
 type args struct {
 	annotation      string
 	apex            string
-	filter          string
+	filters         []string
 	kubecontroller  string
 	loadbalance     string
 	negttl          uint32
@@ -60,7 +60,7 @@ func setup(c *caddy.Controller) error {
 		return plugin.Error(thisPlugin, err)
 	}
 
-	k8sCRD, err := NewK8sCRD(configType(rawArgs.kubecontroller), rawArgs.filter)
+	k8sCRD, err := NewK8sCRD(configType(rawArgs.kubecontroller), rawArgs.filters)
 	if err != nil {
 		return plugin.Error(thisPlugin, err)
 	}
@@ -102,7 +102,7 @@ func parse(c *caddy.Controller) (args, error) {
 			switch key {
 			case "filter":
 				log.Infof("Filter: %+v", args)
-				a.filter = args[0]
+				a.filters = append(a.filters, args[0])
 			case "annotation":
 				log.Infof("annotation: %+v", args)
 				a.annotation = args[0]

--- a/setup_test.go
+++ b/setup_test.go
@@ -34,7 +34,7 @@ func TestParseArguments(t *testing.T) {
 		args          args
 	}{
 		{
-			"valid args",
+			"valid args - single filter",
 			`
 						k8s_crd {
 							filter k8gb.absa.oss/dnstype=local
@@ -45,7 +45,23 @@ func TestParseArguments(t *testing.T) {
 							annotation xy
 						}`,
 			false,
-			args{filter: "k8gb.absa.oss/dnstype=local", negttl: 300, kubecontroller: "local", loadbalance: weightRoundRobin,
+			args{filters: []string{"k8gb.absa.oss/dnstype=local"}, negttl: 300, kubecontroller: "local", loadbalance: weightRoundRobin,
+				zones: []string{}, apex: "xy", annotation: "xy"},
+		},
+		{
+			"valid args - multiple filters",
+			`
+						k8s_crd {
+							filter k8gb.absa.oss/dnstype=local
+							filter k8gb.absa.oss/dnstype=extdns
+							negttl 300
+							kubecontroller local
+							loadbalance weight
+							apex xy
+							annotation xy
+						}`,
+			false,
+			args{filters: []string{"k8gb.absa.oss/dnstype=local", "k8gb.absa.oss/dnstype=extdns"}, negttl: 300, kubecontroller: "local", loadbalance: weightRoundRobin,
 				zones: []string{}, apex: "xy", annotation: "xy"},
 		},
 		{

--- a/terratest/example/dnsendpoint.yaml
+++ b/terratest/example/dnsendpoint.yaml
@@ -20,14 +20,27 @@ spec:
 apiVersion: externaldns.k8s.io/v1alpha1
 kind: DNSEndpoint
 metadata:
-  name: black-list 
+  name: coredns-test-extdns
+  labels:
+    k8gb.absa.oss/dnstype: extdns
 spec:
   endpoints:
   - dnsName: host3.example.org 
     recordType: A
     targets:
-    - 1.2.3.4 
+    - 4.3.2.1
+---
+apiVersion: externaldns.k8s.io/v1alpha1
+kind: DNSEndpoint
+metadata:
+  name: black-list 
+spec:
+  endpoints:
   - dnsName: host4.example.org 
+    recordType: A
+    targets:
+    - 1.2.3.4 
+  - dnsName: host5.example.org 
     recordType: A
     targets:
     - 4.3.2.1 

--- a/terratest/test/basic_test.go
+++ b/terratest/test/basic_test.go
@@ -76,15 +76,23 @@ func TestBasicExample(t *testing.T) {
 		k8s.WaitUntilPodAvailable(t, mainNsOptions, pod.Name, 60, 1*time.Second)
 	}
 
-	t.Run("Basic type A resolve", func(t *testing.T) {
+	// check for reply on local label
+	t.Run("Basic type A resolve on local label", func(t *testing.T) {
 		actualIP, err := DigIPs(t, "localhost", 1053, "host1.example.org", dns.TypeA, clientIP)
 		require.NoError(t, err)
 		assert.Contains(t, actualIP, "1.2.3.4")
 	})
 
-	// check for NODATA replay on non labeled endpoints
-	t.Run("NODATA reply on non labeled endpoints", func(t *testing.T) {
+	// check for reply on extdns label
+	t.Run("Basic type A resolve on extdns label", func(t *testing.T) {
 		emptyIP, err := DigIPs(t, "localhost", 1053, "host3.example.org", dns.TypeA, clientIP)
+		require.NoError(t, err)
+		assert.Contains(t, emptyIP, "4.3.2.1")
+	})
+
+	// check for NODATA reply on non labeled endpoints
+	t.Run("NODATA reply on non labeled endpoints", func(t *testing.T) {
+		emptyIP, err := DigIPs(t, "localhost", 1053, "host4.example.org", dns.TypeA, clientIP)
 		require.NoError(t, err)
 		assert.NotContains(t, emptyIP, "1.2.3.4")
 	})


### PR DESCRIPTION
I would like to serve also correct NS and SOA records for the apex zone. For that, as suggested by @k0da, I would like to read this configuration from the external DNS's DNSEndpoint.

That DNSEndpoint resource has a different label than the remaining DNSEndpoints already read by the plugin. So, as a first step, I am adding the capability of adding multiple filters to the k8s_crd plugin:
```
k8s_crd {
	filter k8gb.absa.oss/dnstype=local
	filter k8gb.absa.oss/dnstype=extdns
```

For reference, this is how the external dns's DNSEndpoint looks like:
```
apiVersion: externaldns.k8s.io/v1alpha1
kind: DNSEndpoint
metadata:
  labels:
    k8gb.absa.oss/dnstype: extdns
  name: k8gb-ns-extdns-cloud-example-com
  namespace: k8gb
spec:
  endpoints:
  - dnsName: cloud.example.com
    recordTTL: 30
    recordType: NS
    targets:
    - eu.cloud.example.com
    - us.cloud.example.com
  - dnsName: eu.cloud.example.com
    recordTTL: 30
    recordType: A
    targets:
    - 172.18.0.11
    - 172.18.0.12
 ```