### PR TITLE
fix: update build toolchain to Go 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k8gb-io/coredns-crd-plugin
 
-go 1.26.1
+go 1.26.6
 
 require (
 	github.com/coredns/caddy v1.1.4-0.20250930002214-15135a999495


### PR DESCRIPTION
Rebuild release artifacts with Go 1.26.6 to include the current standard-library security fixes. This is required by the k8gb LTS release gate.

Combined with #152, a locally built amd64 image reports no vulnerabilities with Grype v0.116.0.

Testing:
- unit suite under Go 1.26.6
- local image build from #152 plus this change
- Grype v0.116.0: no vulnerabilities found

Signed-off-by: Yury Tsarev <yury@0ttl.ai>